### PR TITLE
chore: make app:create:token command pipeable

### DIFF
--- a/app/Console/Commands/CreateAccessToken.php
+++ b/app/Console/Commands/CreateAccessToken.php
@@ -56,7 +56,8 @@ class CreateAccessToken extends Command
         return 0;
     }
 
-    private function entrypointUri(string $token): string {
+    private function entrypointUri(string $token): string
+    {
         $redirect_uris = config('app.redirect_uris');
         $redirect_uri = is_array($redirect_uris) ? $redirect_uris[0] : '';
         $params = ['access_token' => $token, 'redirect_uri' => $redirect_uri];


### PR DESCRIPTION
Tiny change to the `app:create:token` command, making it print a full URL when called from an interactive shell but just the token otherwise, so you can e.g. `php artisan app:create:token | xclip`.