### PR TITLE
fix: Yenlo POST body userHash key

### DIFF
--- a/app/Services/InfoRetrievalGateway/Yenlo.php
+++ b/app/Services/InfoRetrievalGateway/Yenlo.php
@@ -54,7 +54,7 @@ class Yenlo implements InfoRetrievalGateway
 
             $response = $client->post($this->userinfoUrl, [
                 RequestOptions::JSON => [
-                    'userhash' => $userHash,
+                    'userHash' => $userHash,
                 ]
             ]);
 


### PR DESCRIPTION
Potential issue ([the docs](https://github.com/minvws/nl-covid19-coronacheck-provider-docs/blob/main/docs/providing-events-by-patient-id.md#request) have it as `userHash` instead of `userhash`). Currently being validated.