### PR TITLE
chore: add missing arguments to userinfo:retrieve command signature

### DIFF
--- a/app/Console/Commands/RetrieveUserInfo.php
+++ b/app/Console/Commands/RetrieveUserInfo.php
@@ -15,7 +15,7 @@ class RetrieveUserInfo extends Command
     protected CodeGeneratorService $codeGeneratorService;
     protected Yenlo $yenlo;
 
-    protected $signature = 'userinfo:retrieve';
+    protected $signature = 'userinfo:retrieve {patient_id} {birthdate}';
     protected $description = 'Retrieve userinfo from Yenlo based on patient_id and birthdate';
 
     public function __construct(


### PR DESCRIPTION
Fix the `userinfo:retrieve` command by adding the arguments to its `$signature`.