### PR TITLE
fix: phoneNr bug

### DIFF
--- a/app/Anonymizer.php
+++ b/app/Anonymizer.php
@@ -28,13 +28,13 @@ class Anonymizer
             '@' . $parts[1];
     }
 
-    public function phoneNr(string $phoneNr): string
+    public function phoneNumber(string $phoneNumber): string
     {
-        if (strlen($phoneNr) <= 2) {
+        if (strlen($phoneNumber) <= 2) {
             return '****';
         }
 
-        $s = str_repeat('*', strlen($phoneNr) - 2) . substr($phoneNr, -2);
+        $s = str_repeat('*', strlen($phoneNumber) - 2) . substr($phoneNumber, -2);
         while (strlen($s) < 4) {
             $s = '*' . $s;
         }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -171,7 +171,7 @@ class AuthController extends BaseController
             $this->smsService->send($contactInfo->phoneNumber, 'template', ['code' => $code]);
 
             $anonymizer = new Anonymizer();
-            $request->session()->put('confirmation_sent_to', $anonymizer->phoneNr($contactInfo->phoneNumber));
+            $request->session()->put('confirmation_sent_to', $anonymizer->phoneNumber($contactInfo->phoneNumber));
         } else {
             $confirmationType = 'email';
             $this->emailService->send($contactInfo->email, 'template', ['code' => $code]);

--- a/app/Services/InfoRetrievalGateway/Dummy.php
+++ b/app/Services/InfoRetrievalGateway/Dummy.php
@@ -16,7 +16,7 @@ class Dummy implements InfoRetrievalGateway
         $this->hmacKey = $hmacKey;
 
         $this->dummyData = [
-            $this->createHash('12345678', '1976-10-16') => (new UserInfo())->withPhoneNr('06-123456789'),
+            $this->createHash('12345678', '1976-10-16') => (new UserInfo())->withPhoneNumber('06-123456789'),
             $this->createHash('12345678', '1980-01-01') => (new UserInfo())->withEmail('user@example.org'),
         ];
     }

--- a/app/Services/InfoRetrievalGateway/Yenlo.php
+++ b/app/Services/InfoRetrievalGateway/Yenlo.php
@@ -63,8 +63,8 @@ class Yenlo implements InfoRetrievalGateway
             if (isset($data['email'])) {
                 $info->withEmail($data['email']);
             }
-            if (isset($data['phoneNr'])) {
-                $info->withPhonenr($data['phoneNr']);
+            if (isset($data['phoneNumber'])) {
+                $info->withPhoneNumber($data['phoneNumber']);
             }
 
             return $info;

--- a/app/Services/SmsGateway/Dummy.php
+++ b/app/Services/SmsGateway/Dummy.php
@@ -6,7 +6,7 @@ namespace App\Services\SmsGateway;
 
 class Dummy implements SmsGatewayInterface
 {
-    public function send(string $phoneNr, string $template, array $vars): bool
+    public function send(string $phoneNumber, string $template, array $vars): bool
     {
         return true;
     }

--- a/app/Services/SmsGateway/MessageBird.php
+++ b/app/Services/SmsGateway/MessageBird.php
@@ -16,13 +16,13 @@ class MessageBird implements SmsGatewayInterface
         $this->apiKey = $apiKey;
     }
 
-    public function send(string $phoneNr, string $template, array $vars): bool
+    public function send(string $phoneNumber, string $template, array $vars): bool
     {
         $client = new Client($this->apiKey);
 
         $msg = new Message();
         $msg->originator = 'Alarmallama';
-        $msg->recipients = array($phoneNr);
+        $msg->recipients = array($phoneNumber);
         $msg->body = 'Jouw persoonlijke PAP code is ' . $vars['code'];
 
         try {

--- a/app/Services/SmsGateway/SmsGatewayInterface.php
+++ b/app/Services/SmsGateway/SmsGatewayInterface.php
@@ -6,5 +6,5 @@ namespace App\Services\SmsGateway;
 
 interface SmsGatewayInterface
 {
-    public function send(string $phoneNr, string $template, array $vars): bool;
+    public function send(string $phoneNumber, string $template, array $vars): bool;
 }

--- a/app/Services/SmsService.php
+++ b/app/Services/SmsService.php
@@ -15,8 +15,8 @@ class SmsService
         $this->gateway = $gateway;
     }
 
-    public function send(string $phoneNr, string $template, array $vars): bool
+    public function send(string $phoneNumber, string $template, array $vars): bool
     {
-        return $this->gateway->send($phoneNr, $template, $vars);
+        return $this->gateway->send($phoneNumber, $template, $vars);
     }
 }

--- a/app/Services/UserInfo.php
+++ b/app/Services/UserInfo.php
@@ -9,9 +9,9 @@ class UserInfo
     public string $phoneNumber = "";
     public string $email = "";
 
-    public function withPhoneNr(string $phoneNr): UserInfo
+    public function withPhoneNumber(string $phoneNumber): UserInfo
     {
-        $this->phoneNumber = $phoneNr;
+        $this->phoneNumber = $phoneNumber;
         return $this;
     }
 

--- a/tests/Unit/AnonymizerTest.php
+++ b/tests/Unit/AnonymizerTest.php
@@ -20,13 +20,13 @@ class AnonymizerTest extends TestCase
     }
 
     /**
-     * @dataProvider phonenrs
+     * @dataProvider phoneNumbers
      */
-    public function testPhoneNr(string $has, string $want)
+    public function testPhoneNumber(string $has, string $want)
     {
         $anonymizer = new Anonymizer();
 
-        $this->assertEquals($want, $anonymizer->phoneNr($has));
+        $this->assertEquals($want, $anonymizer->phoneNumber($has));
     }
 
     public function emails()
@@ -39,7 +39,7 @@ class AnonymizerTest extends TestCase
         ];
     }
 
-    public function phonenrs(): array
+    public function phoneNumbers(): array
     {
         return [
             [ '0', '****' ],


### PR DESCRIPTION
Update `Yenlo::retrieve` to use `$data["phoneNumber"]` instead of `$data["phoneNr"]` (see [docs](https://github.com/minvws/nl-covid19-coronacheck-provider-docs/blob/main/docs/providing-events-by-patient-id.md#response)).
Also update all other occurrences of `phoneNr` to `phoneNumber` for consistency.
