### PR TITLE
fix: configurable sms sender

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,9 @@ CODEGEN_HMAC_KEY=
 # Number of seconds before expiring authentication codes
 CODEGEN_EXPIRY=900
 
-# Api key for message bird text messaging
+# API key for message bird and SMS sender name
 SMS_GATEWAY_MESSAGEBIRD_API_KEY=
+SMS_GATEWAY_SENDER=
 
 # configuraiton file for oidc clients
 OIDC_CLIENT_CONFIG_JSON=clients.json

--- a/app/Providers/GatewayProvider.php
+++ b/app/Providers/GatewayProvider.php
@@ -20,7 +20,10 @@ class GatewayProvider extends ServiceProvider
     {
         $this->app->singleton(SmsService::class, function () {
             return new SmsService(
-                new MessageBird(config('messagebird.api_key'))
+                new MessageBird(
+                    config('messagebird.api_key'),
+                    config('messagebird.sender'),
+                )
             );
         });
 

--- a/app/Services/SmsGateway/MessageBird.php
+++ b/app/Services/SmsGateway/MessageBird.php
@@ -10,10 +10,12 @@ use MessageBird\Objects\Message;
 class MessageBird implements SmsGatewayInterface
 {
     protected string $apiKey;
+    protected string $sender;
 
-    public function __construct(string $apiKey)
+    public function __construct(string $apiKey, string $sender)
     {
         $this->apiKey = $apiKey;
+        $this->sender = $sender;
     }
 
     public function send(string $phoneNumber, string $template, array $vars): bool
@@ -21,7 +23,7 @@ class MessageBird implements SmsGatewayInterface
         $client = new Client($this->apiKey);
 
         $msg = new Message();
-        $msg->originator = 'Alarmallama';
+        $msg->originator = $this->sender;
         $msg->recipients = array($phoneNumber);
         $msg->body = 'Jouw persoonlijke PAP code is ' . $vars['code'];
 

--- a/config/messagebird.php
+++ b/config/messagebird.php
@@ -4,4 +4,5 @@ declare(strict_types=1);
 
 return [
     'api_key' => env('SMS_GATEWAY_MESSAGEBIRD_API_KEY', ''),
+    'sender' => env('SMS_GATEWAY_SENDER', env('APP_NAME', '')),
 ];


### PR DESCRIPTION
Make SMS sender name configurable via `SMS_GATEWAY_SENDER`. Closes #81.