### PR TITLE
fix: CORS

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -6,6 +6,7 @@ namespace App\Http;
 
 use App\Http\Middleware\OidcSession;
 use App\Http\Middleware\Locale;
+use App\Http\Middleware\Cors;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
@@ -20,7 +21,6 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
@@ -60,5 +60,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'oidc.session' => OidcSession::class,
+        'cors' => Cors::class,
     ];
 }

--- a/app/Http/Middleware/Cors.php
+++ b/app/Http/Middleware/Cors.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Services\Oidc\JsonClientResolver;
+use Closure;
+use Illuminate\Http\Request;
+
+class Cors
+{
+    protected JsonClientResolver $clientResolver;
+
+    public function __construct(JsonClientResolver $clientResolver)
+    {
+        $this->clientResolver = $clientResolver;
+    }
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $response = $next($request);
+
+        if ($request->headers->has('Origin')) {
+            $origin = $request->headers->get('Origin');
+            if (empty($origin)) {
+                return $response;
+            }
+
+            $client_id = $request->get('client_id');
+            $client = $this->clientResolver->resolve($client_id);
+            if (!$client) {
+                return $response;
+            }
+
+            foreach ($client->getRedirectUris() as $uri) {
+                if (str_starts_with($uri, $origin)) {
+                    $response->headers->set('Access-Control-Allow-Origin', $origin);
+                    break;
+                }
+            }
+        }
+
+        return $response;
+    }
+}

--- a/app/Providers/JsonClientResolverProvider.php
+++ b/app/Providers/JsonClientResolverProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Services\Oidc\JsonClientResolver;
+use Illuminate\Support\ServiceProvider;
+
+class JsonClientResolverProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->app->singleton(JsonClientResolver::class, function () {
+            return new JsonClientResolver(base_path(config('oidc.client_config_path')));
+        });
+    }
+}

--- a/app/Providers/OidcProvider.php
+++ b/app/Providers/OidcProvider.php
@@ -16,7 +16,7 @@ class OidcProvider extends ServiceProvider
     {
         $this->app->singleton(OidcService::class, function () {
             return new OidcService(
-                new JsonClientResolver(base_path(config('oidc.client_config_path'))),
+                $this->app->get(JsonClientResolver::class),
                 new CacheStorage(),
                 new JwtService(
                     config('jwt.private_key_path'),

--- a/config/app.php
+++ b/config/app.php
@@ -202,6 +202,7 @@ return [
         App\Providers\CodeGeneratorProvider::class,
         App\Providers\OidcProvider::class,
         App\Providers\JwtProvider::class,
+        App\Providers\JsonClientResolverProvider::class,
     ],
 
     /*

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,8 +11,10 @@ Route::get('/oidc/authorize', function (Request $request, OidcService $oidcServi
     return $oidcService->authorize($request);
 });
 
-Route::post('/oidc/accesstoken', function (Request $request, OidcService $oidcService) {
-    return $oidcService->accessToken($request);
+Route::middleware('cors')->group(function () {
+    Route::post('/oidc/accesstoken', function (Request $request, OidcService $oidcService) {
+        return $oidcService->accessToken($request);
+    });
 });
 
 Route::get('/', function () {


### PR DESCRIPTION
Add `Access-Control-Allow-Origin` response header for `/oidc/accesstoken`, with the origin set to the value of the `Origin` request header if (and only if) it matches one of the `redirect_uris` of the specified client.