### PR TITLE
fix: xss vuln in demo client

### DIFF
--- a/demo-client/callback.html
+++ b/demo-client/callback.html
@@ -111,14 +111,19 @@
 
     function updateTable(element, entries) {
       if (!element) return;
-      const row = (key, value) => {
-        const element = document.createElement("tr");
-        element.innerHTML = `<td>${key}</td><td>${value}</td>`;
-        return element;
-      };
       for (const [key, value] of entries) {
         element.appendChild(row(key, value));
       }
+    }
+
+    function row(...cells) {
+      const row = document.createElement("tr");
+      for (const text of cells) {
+        const cell = document.createElement("td");
+        cell.innerText = text;
+        row.appendChild(cell);
+      }
+      return row;
     }
 
     function updateStateCheck(element, data, params) {


### PR DESCRIPTION
This PR fixes the XSS vuln in the demo client by using `innerText` instead of `innerHTML` to render the query params on the callback page.

![Screenshot of the demo client rendering the query string params as plain text](https://user-images.githubusercontent.com/67802/178266714-08555640-df9d-4267-bf72-a01cfee91a7f.png)
