### PR TITLE
feat: language picker

### DIFF
--- a/resources/scss/language.scss
+++ b/resources/scss/language.scss
@@ -1,0 +1,23 @@
+.language {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  a {
+    font-size: var(--headings-h2-font-size);
+    font-weight: var(--headings-h2-font-weight);
+    text-decoration: none;
+    word-break: normal;
+    padding: 0.5rem;
+    margin: -0.5rem;
+
+    &[aria-current="page"],
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:focus {
+      outline-offset: 0;
+    }
+  }
+}

--- a/resources/scss/main.scss
+++ b/resources/scss/main.scss
@@ -34,3 +34,4 @@
 @use "icons";
 @use "notifications";
 @use "text";
+@use "language";

--- a/resources/scss/overrides/header.scss
+++ b/resources/scss/overrides/header.scss
@@ -2,6 +2,8 @@ $breakpoint: 34rem !default;
 
 body > header > div {
   background: #fff;
+  flex-direction: row;
+  justify-content: space-between;
 
   @media (min-width: $breakpoint) {
     padding-right: 2rem;

--- a/resources/scss/variables.scss
+++ b/resources/scss/variables.scss
@@ -22,6 +22,9 @@
   --headings-h1-line-height: 1.75rem;
   --headings-h2-line-height: 1.5rem;
   --headings-h3-line-height: 1.5rem;
+  --headings-h1-text-color: var(--application-base-accent-color);
+  --headings-h2-text-color: var(--application-base-accent-color);
+  --headings-h3-text-color: var(--application-base-accent-color);
 
   --layout-main-content-block-max-width: 34rem;
   --layout-header-content-block-max-width: 34rem;

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,5 +1,15 @@
 <header>
     <div>
         <img src="/logo.svg" alt="GGD GHOR" width="84px" height="39.06px">
+        <div class="language">
+            <a
+                href="{{ url()->current() . '?lang=nl' }}"
+                aria-current="{{ App::isLocale('nl') ? 'page' : 'false' }}"
+            >NL</a>
+            <a
+                href="{{ url()->current() . '?lang=en' }}"
+                aria-current="{{ App::isLocale('en') ? 'page' : 'false' }}"
+            >EN</a>
+        </div>
     </div>
 </header>


### PR DESCRIPTION
Add a bargain bin language picker, since the accessible drop-down version isn't done yet.

State|Screenshot
--|--
Default|<img src="https://user-images.githubusercontent.com/67802/178930072-d576a8fc-81e2-4945-8602-023757d6948a.png" width="360px" />
Hover|<img src="https://user-images.githubusercontent.com/67802/178930065-62fb94e5-6328-4ce6-b90f-c57b4f07d908.png" width="360px" />
Focus|<img src="https://user-images.githubusercontent.com/67802/178930068-e9b52b50-a540-47c9-b3ac-04be26128f5a.png" width="360px" />

Focus outline matches touch area.