### PR TITLE
fix: language picker underline

### DIFF
--- a/resources/scss/language.scss
+++ b/resources/scss/language.scss
@@ -8,12 +8,12 @@
     font-weight: var(--headings-h2-font-weight);
     text-decoration: none;
     word-break: normal;
-    padding: 0.5rem;
-    margin: -0.5rem;
+    padding: 0rem 0.5rem;
+    border-bottom: 2px solid #fff;
 
     &[aria-current="page"],
     &:hover {
-      text-decoration: underline;
+      border-bottom: 2px solid var(--application-base-accent-color);
     }
 
     &:focus {


### PR DESCRIPTION
Normal|Hover
--|--
![Screenshot of language picker with tweaked underline, normal state](https://user-images.githubusercontent.com/67802/183832315-2a0389d0-ded7-458c-bc71-55e04e6474ab.png)|![Screenshot of language picker with tweaked underline, hover state](https://user-images.githubusercontent.com/67802/183832318-b857449b-cc96-4424-b674-d99e5e5cc7cc.png)

