### PR TITLE
fix: lang switcher accessibility

### DIFF
--- a/resources/scss/language.scss
+++ b/resources/scss/language.scss
@@ -1,7 +1,10 @@
+@use "sr-only";
+
 .language {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  margin: 0;
 
   a {
     font-size: var(--headings-h2-font-size);
@@ -18,6 +21,10 @@
 
     &:focus {
       outline-offset: 0;
+    }
+
+    span {
+      @extend .sr-only;
     }
   }
 }

--- a/resources/scss/sr-only.scss
+++ b/resources/scss/sr-only.scss
@@ -1,0 +1,11 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,15 +1,17 @@
 <header>
     <div>
         <img src="/logo.svg" alt="Logo GGD GHOR" width="84px" height="39.06px">
-        <div class="language">
+        <ul class="language">
             <a
                 href="{{ url()->current() . '?lang=nl' }}"
                 aria-current="{{ App::isLocale('nl') ? 'page' : 'false' }}"
-            >NL</a>
+                lang="nl"
+            >NL <span>(deze pagina in het Nederlands)</span></a>
             <a
                 href="{{ url()->current() . '?lang=en' }}"
                 aria-current="{{ App::isLocale('en') ? 'page' : 'false' }}"
-            >EN</a>
-        </div>
+                lang="en"
+            >EN <span>(this page in English)</span></a>
+        </ul>
     </div>
 </header>


### PR DESCRIPTION
Improve language switcher accessibility by changing to a `<ul>` (to ensure `aria-current` is applied correctly) and adding a visually-hidden span "this page in English" / "deze pagina in het Nederlands".

Closes #170
Closes #171
