### PR TITLE
Update deprecated github actions set-output

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
Update for https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/